### PR TITLE
Add commands to do likes in bigger batches

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,5 +1,6 @@
 import socket
 import argparse
+import time
 
 def push_like_button(SERVER_PORT):
     # Connect to Node 1
@@ -14,15 +15,23 @@ def push_like_button(SERVER_PORT):
 
 def main(SERVER_PORT):
     while True:
-        command = input("Enter command ('like' or 'exit'): ")
+        command = input("Enter command ('like' or 'like many' or 'exit'): ")
 
         if command == 'like':
             push_like_button(SERVER_PORT)
         elif command == 'exit':
             print("Exiting.")
             break
+        elif command == 'like many':
+            sleep = input("Enter sleep:")
+            amount_of_like_events = input("Enter amount of like events:")
+            time.sleep(int(sleep))
+            for x in range(int(amount_of_like_events)):
+                push_like_button(SERVER_PORT)
+                time.sleep(0.01)
+            print(f'Liked {amount_of_like_events} times')
         else:
-            print("Invalid command. Please enter 'like' or 'exit'.")
+            print("Invalid command. Please enter 'like' or 'like many' or 'exit'.")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Client for sending 'like' requests")

--- a/server.py
+++ b/server.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # Start server to handle client requests
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.bind(('localhost', SERVER_PORT))
-    server.listen(5)
+    server.listen(5) # The number 5 here is the max amount of incoming connections (clients)
     print(f"Server listening on port {SERVER_PORT}")
 
     while True:


### PR DESCRIPTION
I added functionality for load testing. You can now run the client with the "like many" mode. Enter sleep time in seconds -> gives you time to do the same stuff in other terminal windows. Enter the amount of likes e.g. 500.
Open multiple clients in separate terminal windows and run the likes in parallel and check from the sever nodes wether the state was updated correctly.