### PR TITLE
Add leader server and functionality

### DIFF
--- a/leader.py
+++ b/leader.py
@@ -1,0 +1,70 @@
+import socket
+import threading
+
+LEADER_ADDRESS = ('localhost', 5001)
+
+# Dictionary to store information about other server nodes: {node_id: (ip_address, port)}
+list_of_servers = {}
+id_count = 0
+
+def handle_new_server(node_socket, notifications_port):
+    add_new_node_to_list(notifications_port)
+    inform_other_nodes()
+    node_socket.close()
+
+
+def send_node_information(node_socket):
+    node_info = "server_info\n" + '\n'.join([f"{node_id}:{address[0]}:{address[1]}" for node_id, address in list_of_servers.items()])
+    node_socket.sendall(node_info.encode())
+
+
+def handle_node(node_socket):
+    send_node_information(node_socket)
+    node_socket.close()
+
+
+def inform_other_nodes():
+    # Inform all existing servers about the updated node information
+    updated_node_info = "server_info\n" + '\n'.join([f"{node_id}:{address[0]}:{address[1]}" for node_id, address in list_of_servers.items()])
+    
+    for node_id, address in list_of_servers.items():
+        client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ADDRESS = ('localhost', address[1])
+        client_socket.connect(ADDRESS)
+        client_socket.sendall(updated_node_info.encode())
+        client_socket.close()
+
+
+def leader_server():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(LEADER_ADDRESS)
+    server.listen(5)
+    print(f"Leader server listening on {LEADER_ADDRESS}")
+
+    while True:
+      node_socket, node_address = server.accept()
+      print(f"Connection from {node_address}")
+      # Check if it's a new server joining or an existing server communicating
+      received_data = node_socket.recv(1024).decode()
+      if received_data.startswith("join_request"):
+          message, ip, receive_port = received_data.split(':')
+          threading.Thread(target=handle_new_server, args=(node_socket, receive_port)).start()
+      else:
+          threading.Thread(target=handle_node, args=(node_socket, receive_port)).start()
+
+
+def add_new_node_to_list(notifications_port):
+    global id_count
+    print(f'Adding a new node')
+    
+    # Should the node id come from the node itself or does the leader decide it?
+    id_count += 1
+    node_id = id_count
+
+    ip = 'localhost' # Todo: add possibility to configure other addresses
+    list_of_servers[node_id] = (ip, int(notifications_port))
+    print(f"Added new server: {node_id} - {ip}:{notifications_port}")
+
+
+if __name__ == "__main__":
+    leader_server()

--- a/server.py
+++ b/server.py
@@ -2,77 +2,120 @@ import socket
 import threading
 import argparse
 
-liked_count = 0
+
 lock = threading.Lock()
+like_count = 0
+LEADER_ADDRESS = ('localhost', 5001)
+own_port = 0
+notification_port = 0
+other_nodes = {}
 
 def handle_client(client_socket):
-    global liked_count
+    global like_count
+    
     while True:
-        # Receive client request
         data = client_socket.recv(1024)
         if not data:
             break
         
         # Process like request
-        with lock:
-            liked_count += 1
-            print(f"Received like. Liked count: {liked_count}")
-            send_notifications(OTHER_PORTS, 1)
+        _update_likes()
+        print(f"Received like. Like count: {like_count}")
+        send_notifications(other_nodes)
 
     client_socket.close()
 
 
-def send_notifications(other_ports, liked_count_change):
-    for port in other_ports:
+# Todo: Modify the message to contain more info (timestamp, node_id)
+def send_notifications(other_nodes):
+    for node in other_nodes:
+        port = int(other_nodes[node][1])
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as node_socket:
             node_socket.connect(('localhost', port))
-            node_socket.sendall(str(liked_count_change).encode())
+            node_socket.sendall("Like event".encode())
             print(f"Sent notification to node on port {port}")
 
 
-def receive_notifications(port):
-    global liked_count
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
-        server_socket.bind(('localhost', port))
-        server_socket.listen(5)
-        print(f"Notification server listening on port {port}")
-
-        while True:
-            client_socket, client_address = server_socket.accept()
-            print(f"Notification connection from {client_address}")
-
-            data = client_socket.recv(1024)
-            if data:
-                with lock:
-                    liked_count += int(data.decode())
-                    print(f"Received notification. Liked count: {liked_count}")
-
-            client_socket.close()
+def _update_likes():
+    global like_count
+    with lock:
+        like_count += 1
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Server for handling 'like' requests and notifications")
-    parser.add_argument('port', type=int, help="Port number for handling client requests")
-    parser.add_argument('notification_port', type=int, help="Port number for receiving notifications")
-    parser.add_argument('other_ports', nargs='+', type=int, help="Ports to send notifications")
-    args = parser.parse_args()
+def connect_to_leader():
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(LEADER_ADDRESS)
+    print(f"Connected to leader node at {LEADER_ADDRESS}")
 
-    SERVER_PORT = args.port
-    NOTIFICATION_PORT = args.notification_port
-    OTHER_PORTS = args.other_ports
+    # Inform the leader that this is a new server node
+    new_node_info = f'join_request\nnew_node:localhost:{notification_port}'  # Replace with appropriate node info
+    client.sendall(new_node_info.encode())
 
-    # Start thread to listen for notifications from other nodes
-    notification_thread = threading.Thread(target=receive_notifications, args=(NOTIFICATION_PORT,))
-    notification_thread.start()
+    # Receive node information from the leader
+    # node_info = client.recv(1024).decode()
+    client.close()
 
-    # Start server to handle client requests
+
+def handle_notifications(other_node_socket):
+    global like_count
+    data = other_node_socket.recv(1024)
+    if data:
+        if data.decode().startswith("server_info"): # Means that a notification is coming from the leader
+            handle_leader_notification(data.decode())
+        else: # Like event
+            _update_likes()
+            print(f"Received notification. Liked count: {like_count}")
+
+
+def handle_leader_notification(data):
+    print(f'Received notification from the leader')
+    
+    # Parse the node information from the message
+    title, nodes_string = data.split('\n', 1)
+    nodes = nodes_string.split('\n')
+    for node in nodes:
+        node_id, ip, port = node.split(':')
+        if int(port) != notification_port:
+            other_nodes[node_id] = (ip, port)
+
+    print(f'Updated server nodes: {other_nodes}')
+
+
+def handle_client_thread():
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server.bind(('localhost', SERVER_PORT))
+    server.bind(('localhost', own_port))
     server.listen(5)
-    print(f"Server listening on port {SERVER_PORT}")
+    print(f"Server listening on port {own_port}")
 
     while True:
         client_socket, client_address = server.accept()
         print(f"Connection from {client_address}")
-        client_handler = threading.Thread(target=handle_client, args=(client_socket,))
-        client_handler.start()
+        handle_client(client_socket)
+
+
+def handle_notifications_thread():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+        server_socket.bind(('localhost', notification_port))
+        server_socket.listen(5)
+        print(f"Notification server listening on port {notification_port}")
+
+        while True:
+            other_node_socket, other_node_address = server_socket.accept()
+            print(f"Notification connection from {other_node_address}")
+            handle_notifications(other_node_socket)
+            other_node_socket.close() # Not sure if this has to be here...
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Server for handling 'like' requests and notifications")
+    own_port = int(input("Give a port number for receiving messages from clients:"))
+    notification_port = int(input("Give a port number for receiving notifications:"))
+    
+    connect_to_leader()
+
+    notification_thread = threading.Thread(target=handle_notifications_thread, args=())
+    notification_thread.start()
+
+    client_thread = threading.Thread(target=handle_client_thread, args=())
+    client_thread.start()
+    


### PR DESCRIPTION
Leader is now hardcoded to port 5001. It should be started first. Servers can be started after the leader and the leader will know the addresses to all servers.